### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/permit2.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # permit2
 
 Permit2 introduces a low-overhead, next-generation token approval/meta-tx system to make token approvals easier, more secure, and more consistent across applications.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@uniswap/permit2",
-  "description": "Low-overhead, next generation token approval/meta-tx system to make token approvals easier, more secure, and more consistent across applications",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "version": "1.0.0",
-  "bugs": "https://github.com/Uniswap/permit2/issues",
+  "bugs": {
+    "url": "https://github.com/primeanetwork/permit2/issues"
+  },
   "keywords": [
     "ethereum",
     "permit2",
@@ -11,6 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/permit2.git"
-  }
+    "url": "git+ssh://git@github.com/primeanetwork/permit2.git"
+  },
+  "homepage": "https://github.com/primeanetwork/permit2#readme"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/permit2`. **No product code changes.**